### PR TITLE
Feature/howconsume

### DIFF
--- a/convo.go
+++ b/convo.go
@@ -54,21 +54,40 @@ func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.C
 	var sinkMessage *MsgWrap
 	switch value {
 	case "sql":
-		sinkMessage = c.Msg().Message("Sink to SQL: See https://docs.substreams.dev/how-to-guides/sinks/sql-sink")
-	case "csv":
-		sinkMessage = c.Msg().Message("Sink to CSV file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
-	case "json":
-		sinkMessage = c.Msg().Message("Sink to JSON file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
+		sinkMessage = c.Msg().Message(`Sink to SQL:
+		1. Get the binary from https://github.com/streamingfast/substreams-sink-sql/ (version 4.6.1 or above)
+		2. Run ` + "`substreams-sink-sql from-proto psql://db_user:db_password@db_host:5432/db_name ./substreams.yaml {output_module}`" +
+			` See https://docs.substreams.dev/how-to-guides/sinks/sql-sink"`)
 	case "parquet":
-		sinkMessage = c.Msg().Message("Sink to Parquet file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
+		sinkMessage = c.Msg().Message(`Sink to Parquet file:
+			1. Get the binary from https://github.com/streamingfast/substreams-sink-files/ (version 2.1.0 or above)
+			2. Run ` + "`substreams-sink-files run {endpoint} substreams.yaml {output_module} ./output`" +
+			` See https://docs.substreams.dev/how-to-guides/sinks/sql-sink"`)
 	case "golang":
-		sinkMessage = c.Msg().Message("Stream using Go: https://docs.substreams.dev/how-to-guides/sinks/stream/go")
+		sinkMessage = c.Msg().Message(`Sink using Golang
+
+    		We provide a Substreams Golang SDK to streamline consumption of Substreams data
+    		refer to https://github.com/streamingfast/substreams-sink for more details and examples.`)
 	case "rust":
-		sinkMessage = c.Msg().Message("Stream using Rust: https://github.com/streamingfast/substreams-sink-examples/tree/master/rust#readme")
+		sinkMessage = c.Msg().Message(`Sink using Rust
+
+			Here is an example of a Rust sink: https://github.com/streamingfast/substreams-sink-examples/tree/master/rust#readme`)
 	case "javascript":
-		sinkMessage = c.Msg().Message("Stream using JavaScript: https://docs.substreams.dev/how-to-guides/sinks/stream/javascript")
-	case "pubsub":
-		sinkMessage = c.Msg().Message("Stream using Pub/Sub: https://docs.substreams.dev/how-to-guides/sinks/pubsub")
+		sinkMessage = c.Msg().Message(`Sink using Javascript
+
+		Here is an example of a JS sink: https://github.com/streamingfast/substreams-sink-examples/blob/master/javascript/README.md`)
+
+	case "python":
+		sinkMessage = c.Msg().Message(`Sink using Python
+
+			Here is an example of a Python sink: https://github.com/streamingfast/substreams-sink-examples/blob/master/python/README.md`)
+
+	//case "pubsub":
+	//	sinkMessage = c.Msg().Message("Stream using Pub/Sub: (Not implemented yet)")
+	//case "json":
+	//	sinkMessage = c.Msg().Message("Sink to JSON file: (Not implemented yet)")
+	//case "csv":
+	//	sinkMessage = c.Msg().Message("Sink to CSV file: (Not implemented yet)")
 	default:
 		sinkMessage = c.Msg().Message("Invalid choice")
 	}
@@ -81,8 +100,28 @@ func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.C
 
 func (c *Conversation[X]) downloadedCommands(destDir string) []loop.Cmd {
 
-	values := []string{"sql", "csv", "json", "parquet", "golang", "rust", "javascript", "pubsub"}
-	labels := []string{"To SQL", "To CSV Files", "To JSON Files", "To Parquet Files", "Stream using Golang", "Stream using Rust", "Stream using JavaScript/TypeScript", "Stream to Pub/Sub"}
+	values := []string{
+		"sql",
+		//"csv",
+		//"json",
+		"parquet",
+		"golang",
+		"rust",
+		"javascript",
+		"python",
+		//"pubsub",
+	}
+	labels := []string{
+		"To SQL",
+		//"To CSV Files",
+		//"To JSON Files",
+		"To Parquet Files",
+		"Write a custom sink in Go",
+		"Write a custom sink in Rust",
+		"Write a custom sink in JavaScript/TypeScript",
+		"Write a custom sink in Python",
+		//"Stream to Pub/Sub",
+	}
 
 	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?", "consumption").
 		Labels(labels...).

--- a/convo.go
+++ b/convo.go
@@ -10,11 +10,16 @@ import (
 type Conversation[X any] struct {
 	State X
 
-	factory *MsgWrapFactory
+	clientVersion uint32
+	factory       *MsgWrapFactory
 }
 
 func (c *Conversation[X]) SetFactory(f *MsgWrapFactory) {
 	c.factory = f
+}
+
+func (c *Conversation[X]) SetClientVersion(version uint32) {
+	c.clientVersion = version
 }
 
 func (c *Conversation[X]) GetState() any {
@@ -46,7 +51,6 @@ func (c *Conversation[X]) CmdAskProjectName() loop.Cmd {
 }
 
 func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.Cmd {
-
 	var sinkMessage *MsgWrap
 	switch value {
 	case "sql":
@@ -75,6 +79,45 @@ func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.C
 	)
 }
 
+func (c *Conversation[X]) downloadedCommands(destDir string) []loop.Cmd {
+
+	values := []string{"sql", "csv", "json", "parquet", "golang", "rust", "javascript", "pubsub"}
+	labels := []string{"To SQL", "To CSV Files", "To JSON Files", "To Parquet Files", "Stream using Golang", "Stream using Rust", "Stream using JavaScript/TypeScript", "Stream to Pub/Sub"}
+
+	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?", "consumption").
+		Labels(labels...).
+		Values(values...)
+
+	return []loop.Cmd{
+		c.Msg().Messagef(`Your Substreams project is ready! Start streaming with:
+
+`+"```"+`bash
+
+cd %s
+substreams build
+substreams auth
+substreams gui       			  # Get streaming!
+`+"```"+`
+
+Optionally, publish your Substreams to the Substreams Registry (https://substreams.dev) with:
+
+`+"```"+`bash
+substreams registry login         # Login to substreams.dev
+substreams registry publish       # Publish your Substreams to substreams.dev
+`+"```"+`
+
+`, destDir).Cmd(),
+		act.Cmd(),
+	}
+}
+
+func (c *Conversation[X]) HandleDownloaded(destDir string) loop.Cmd {
+	return loop.Seq(
+		c.downloadedCommands(destDir)...,
+	)
+
+}
+
 func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 	if msg.Err != nil {
 		return loop.Seq(
@@ -92,38 +135,14 @@ func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 		}
 		downloadCmd.AddFile(fileName, msg.ProjectFiles[fileName], "text/plain", fileDescription)
 	}
-	values := []string{"sql", "csv", "json", "parquet", "golang", "rust", "javascript", "pubsub"}
-	labels := []string{"To SQL", "To CSV Files", "To JSON Files", "To Parquet Files", "Stream using Golang", "Stream using Rust", "Stream using JavaScript/TypeScript", "Stream to Pub/Sub"}
 
-	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?", "consumption").
-		Labels(labels...).
-		Values(values...)
+	if c.clientVersion >= 4 {
+		return downloadCmd.Cmd()
+	}
 
 	return loop.Seq(
 		downloadCmd.Cmd(),
-		c.Msg().Messagef(`Your Substreams project is ready! Start streaming with:
-
-`+"```"+`bash
-substreams build
-substreams auth
-substreams gui       			  # Get streaming!
-`+"```"+`
-
-Build Subgraphs and other sinks with:
-
-`+"```"+`bash
-substreams codegen subgraph
-substreams codegen sql
-`+"```"+`
-
-Optionally, publish your Substreams to the Substreams Registry (https://substreams.dev) with:
-
-`+"```"+`bash
-substreams registry login         # Login to substreams.dev
-substreams registry publish       # Publish your Substreams to substreams.dev
-`+"```"+`
-
-`).Cmd(),
-		act.Cmd(),
+		c.HandleDownloaded("{project folder}"),
 	)
+
 }

--- a/convo.go
+++ b/convo.go
@@ -46,8 +46,31 @@ func (c *Conversation[X]) CmdAskProjectName() loop.Cmd {
 }
 
 func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.Cmd {
+
+	var sinkMessage *MsgWrap
+	switch value {
+	case "sql":
+		sinkMessage = c.Msg().Message("Sink to SQL: See https://docs.substreams.dev/how-to-guides/sinks/sql-sink")
+	case "csv":
+		sinkMessage = c.Msg().Message("Sink to CSV file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
+	case "json":
+		sinkMessage = c.Msg().Message("Sink to JSON file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
+	case "parquet":
+		sinkMessage = c.Msg().Message("Sink to Parquet file: See https://docs.substreams.dev/how-to-guides/sinks/community-sinks/files")
+	case "golang":
+		sinkMessage = c.Msg().Message("Stream using Go: https://docs.substreams.dev/how-to-guides/sinks/stream/go")
+	case "rust":
+		sinkMessage = c.Msg().Message("Stream using Rust: https://github.com/streamingfast/substreams-sink-examples/tree/master/rust#readme")
+	case "javascript":
+		sinkMessage = c.Msg().Message("Stream using JavaScript: https://docs.substreams.dev/how-to-guides/sinks/stream/javascript")
+	case "pubsub":
+		sinkMessage = c.Msg().Message("Stream using Pub/Sub: https://docs.substreams.dev/how-to-guides/sinks/pubsub")
+	default:
+		sinkMessage = c.Msg().Message("Invalid choice")
+	}
+
 	return loop.Seq(
-		c.Msg().Messagef(`You chose the %s`, value).Cmd(),
+		sinkMessage.Cmd(),
 		loop.Quit(nil),
 	)
 }
@@ -69,9 +92,8 @@ func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 		}
 		downloadCmd.AddFile(fileName, msg.ProjectFiles[fileName], "text/plain", fileDescription)
 	}
-
-	values := []string{"sql", "pubsub"}
-	labels := []string{"SQL", "Through PubSub messaging"}
+	values := []string{"sql", "csv", "json", "parquet", "golang", "rust", "javascript", "pubsub"}
+	labels := []string{"To SQL", "To CSV Files", "To JSON Files", "To Parquet Files", "Stream using Golang", "Stream using Rust", "Stream using JavaScript/TypeScript", "Stream to Pub/Sub"}
 
 	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?").
 		Labels(labels...).

--- a/convo.go
+++ b/convo.go
@@ -95,7 +95,7 @@ func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 	values := []string{"sql", "csv", "json", "parquet", "golang", "rust", "javascript", "pubsub"}
 	labels := []string{"To SQL", "To CSV Files", "To JSON Files", "To Parquet Files", "Stream using Golang", "Stream using Rust", "Stream using JavaScript/TypeScript", "Stream to Pub/Sub"}
 
-	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?").
+	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?", "consumption").
 		Labels(labels...).
 		Values(values...)
 

--- a/convo.go
+++ b/convo.go
@@ -45,6 +45,13 @@ func (c *Conversation[X]) CmdAskProjectName() loop.Cmd {
 		Cmd()
 }
 
+func (c *Conversation[X]) HandleSubstreamsConsumptionChoice(value string) loop.Cmd {
+	return loop.Seq(
+		c.Msg().Messagef(`You chose the %s`, value).Cmd(),
+		loop.Quit(nil),
+	)
+}
+
 func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 	if msg.Err != nil {
 		return loop.Seq(
@@ -62,6 +69,13 @@ func (c *Conversation[X]) CmdDownloadFiles(msg ReturnGenerate) loop.Cmd {
 		}
 		downloadCmd.AddFile(fileName, msg.ProjectFiles[fileName], "text/plain", fileDescription)
 	}
+
+	values := []string{"sql", "pubsub"}
+	labels := []string{"SQL", "Through PubSub messaging"}
+
+	act := c.Action(InputSubstreamsConsumptionChoice{}).ListSelect("How would you like to consume the Substreams?").
+		Labels(labels...).
+		Values(values...)
 
 	return loop.Seq(
 		downloadCmd.Cmd(),
@@ -88,6 +102,6 @@ substreams registry publish       # Publish your Substreams to substreams.dev
 `+"```"+`
 
 `).Cmd(),
-		loop.Quit(nil),
+		act.Cmd(),
 	)
 }

--- a/evm-events-calls-raw/convo.go
+++ b/evm-events-calls-raw/convo.go
@@ -144,6 +144,8 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		return c.Msg().
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/evm-events-calls-raw/convo.go
+++ b/evm-events-calls-raw/convo.go
@@ -104,6 +104,7 @@ func (c *Convo) NextStep() (out loop.Cmd) {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -146,6 +147,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Cmd()
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/evm-events-calls-raw/convo.go
+++ b/evm-events-calls-raw/convo.go
@@ -133,7 +133,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		act := c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		act := c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...)
 		act.DefaultValue("mainnet")
@@ -301,7 +301,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			return c.NextStep()
 		}
 		act := c.Action(InputContractTrackWhat{}).
-			ListSelect("What do you want to track for this contract?").
+			ListSelect("What do you want to track for this contract?", "calls_or_events").
 			Labels("Events", "Calls", "Both events and calls").
 			Values("events", "calls", "both")
 		if contract.Address == UNISWAP_V3_FACTORY_ADDRESS {

--- a/evm-events-calls/convo.go
+++ b/evm-events-calls/convo.go
@@ -218,6 +218,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		}
 		return c.NextStep()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case StartFirstContract:
 		c.State.Contracts = append(c.State.Contracts, &Contract{})
 		return c.NextStep()

--- a/evm-events-calls/convo.go
+++ b/evm-events-calls/convo.go
@@ -167,6 +167,7 @@ func (c *Convo) NextStep() (out loop.Cmd) {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -220,6 +221,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case StartFirstContract:
 		c.State.Contracts = append(c.State.Contracts, &Contract{})

--- a/evm-events-calls/convo.go
+++ b/evm-events-calls/convo.go
@@ -196,7 +196,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		act := c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		act := c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...)
 		act.DefaultValue("mainnet")
@@ -295,7 +295,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		}
 
 		return c.Action(InputContractABIType{}).
-			ListSelect("How do you want to provide the JSON ABI?").
+			ListSelect("How do you want to provide the JSON ABI?", "ABI type").
 			Labels("JSON string", "JSON in a local file").
 			Values("string", "file").
 			DefaultValue("string").
@@ -728,7 +728,7 @@ message {{.Proto.MessageName}} {{.Proto.OutputModuleFieldName}} {
 			return c.NextStep()
 		}
 		act := c.Action(InputContractTrackWhat{}).
-			ListSelect("What do you want to track for this contract?").
+			ListSelect("What do you want to track for this contract?", "track").
 			Labels("Events", "Calls", "Both events and calls").
 			Values("events", "calls", "both")
 		if contract.Address == UNISWAP_V3_FACTORY_ADDRESS {
@@ -761,7 +761,7 @@ message {{.Proto.MessageName}} {{.Proto.OutputModuleFieldName}} {
 		}
 
 		act := c.Action(InputDynamicContractTrackWhat{}).
-			ListSelect("What do you want to track for the contracts that will be created by this factory ?").
+			ListSelect("What do you want to track for the contracts that will be created by this factory?", "track_subcontract").
 			Labels("Events", "Calls", "Both events and calls").
 			Values("events", "calls", "both")
 		act = act.DefaultValue("both")
@@ -828,7 +828,7 @@ message {{.Proto.MessageName}} {{.Proto.OutputModuleFieldName}} {
 			values = append(values, events[k])
 		}
 		act := c.Action(InputFactoryCreationEvent{}).
-			ListSelect("Choose the event signaling a new contract deployment").
+			ListSelect("Choose the event signaling a new contract deployment", "event").
 			Labels(values...).
 			Values(keys...)
 		act.DefaultValue("PoolCreated")
@@ -870,7 +870,7 @@ message {{.Proto.MessageName}} {{.Proto.OutputModuleFieldName}} {
 				Message("Great, now which field in the event payload contains the address of the newly created contract?").
 				Cmd(),
 			c.Action(InputFactoryCreationEventField{}).
-				ListSelect("Choose the field containing the contract address").
+				ListSelect("Choose the field containing the contract address", "field").
 				DefaultValue(defaultValue).
 				Labels(params...).
 				Values(indexes...).

--- a/evm-events-calls/convo_test.go
+++ b/evm-events-calls/convo_test.go
@@ -142,20 +142,23 @@ func TestConvoUpdate(t *testing.T) {
 	next = conv.Update(codegen.ReturnGenerate{ProjectFiles: nil})
 	seq = next().(loop.SeqMsg)
 
-	//cmds := next()
-	msg1 := seq[1]().(*pbconvo.SystemOutput)
+	// First part of sequence should be the download files command
+	downloadMsg := seq[0]().(*pbconvo.SystemOutput)
+	assert.NotNil(t, downloadMsg.GetDownloadFiles())
 
+	// Second part should trigger InputSourceDownloaded which leads to the project ready message
+	next = conv.Update(codegen.InputSourceDownloaded{pbconvo.UserInput_TextInput{Value: "{project folder}"}})
+	seq = next().(loop.SeqMsg)
+	
+	// Now the project ready message should be in the first part of this new sequence
+	msg1 := seq[0]().(*pbconvo.SystemOutput)
 	assert.Contains(t, msg1.GetMessage().Markdown, "substreams build\nsubstreams auth\nsubstreams gui")
 	assert.Contains(t, msg1.GetMessage().Markdown, "substreams registry login")
 	assert.Contains(t, msg1.GetMessage().Markdown, "substreams registry publish")
-	//msg2 := seq[1]().(*pbconvo.SystemOutput)
-	//assert.NotNil(t, msg2.GetDownloadFiles())
-	//
-	//next = conv.Update(codegen.InputSourceDownloaded{})
-	//assert.Equal(t, codegen.AskConfirmCompile{}, next())
-	//
-	//next = conv.Update(codegen.InputConfirmCompile{UserInput_Confirmation: pbconvo.UserInput_Confirmation{Affirmative: true}})
-	//assert.Equal(t, codegen.RunBuild{}, next())
+	
+	// Second part should be the consumption choice selection
+	consumptionMsg := seq[1]().(*pbconvo.SystemOutput)
+	assert.NotNil(t, consumptionMsg.GetListSelect())
 
 }
 

--- a/evm-minimal/convo.go
+++ b/evm-minimal/convo.go
@@ -83,7 +83,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/evm-minimal/convo.go
+++ b/evm-minimal/convo.go
@@ -58,6 +58,7 @@ func isValidChainName(input string) bool {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -95,6 +96,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/evm-minimal/convo.go
+++ b/evm-minimal/convo.go
@@ -93,6 +93,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if isValidChainName(msg.Value) {

--- a/injective-events/convo.go
+++ b/injective-events/convo.go
@@ -103,6 +103,7 @@ func (c *Convo) NextStep() (out loop.Cmd) {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -139,6 +140,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/injective-events/convo.go
+++ b/injective-events/convo.go
@@ -127,7 +127,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
@@ -183,8 +183,8 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		}
 		values := []string{EVENTS_DATA_TYPE, EVENT_GROUPS_DATA_TYPE}
 		return c.Action(InputDataType{}).
-			ListSelect(fmt.Sprintf("This codegen will build a substreams that filters data based on events.\n" +
-				"Do you want to target:")).
+			ListSelect(fmt.Sprintf("This codegen will build a substreams that filters data based on events.\n"+
+				"Do you want to target:"), "target_type").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
@@ -259,7 +259,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		return loop.Seq(
 			c.Msg().Messagef("Current filtering event types %q", c.State.GetEventsQuery()).Cmd(),
 			c.Action(InputAskAnotherEventType{}).
-				ListSelect("Do you want to add another event type").
+				ListSelect("Do you want to add another event type", "other_event_type").
 				Labels("Yes", "No").
 				Values("yes", "no").Cmd(),
 		)

--- a/injective-events/convo.go
+++ b/injective-events/convo.go
@@ -137,6 +137,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if isValidChainName(msg.Value) {

--- a/injective-minimal/convo.go
+++ b/injective-minimal/convo.go
@@ -92,6 +92,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/injective-minimal/convo.go
+++ b/injective-minimal/convo.go
@@ -57,6 +57,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -94,6 +95,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/injective-minimal/convo.go
+++ b/injective-minimal/convo.go
@@ -82,7 +82,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/interfaces.go
+++ b/interfaces.go
@@ -12,6 +12,7 @@ type ConversationFactory func() Converser
 type Converser interface {
 	// Functions provided by the Conversation instance
 
+	SetClientVersion(uint32)
 	NextStep() loop.Cmd
 	Update(loop.Msg) loop.Cmd
 

--- a/mantra-events/convo.go
+++ b/mantra-events/convo.go
@@ -103,6 +103,7 @@ func (c *Convo) NextStep() (out loop.Cmd) {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -139,6 +140,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/mantra-events/convo.go
+++ b/mantra-events/convo.go
@@ -127,7 +127,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
@@ -183,8 +183,8 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		}
 		values := []string{EVENTS_DATA_TYPE, EVENT_GROUPS_DATA_TYPE}
 		return c.Action(InputDataType{}).
-			ListSelect(fmt.Sprintf("This codegen will build a substreams that filters data based on events.\n" +
-				"Do you want to target:")).
+			ListSelect(fmt.Sprintf("This codegen will build a substreams that filters data based on events.\n"+
+				"Do you want to target:"), "target_type").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
@@ -259,7 +259,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		return loop.Seq(
 			c.Msg().Messagef("Current filtering event types %q", c.State.GetEventsQuery()).Cmd(),
 			c.Action(InputAskAnotherEventType{}).
-				ListSelect("Do you want to add another event type").
+				ListSelect("Do you want to add another event type", "other_event_type").
 				Labels("Yes", "No").
 				Values("yes", "no").Cmd(),
 		)

--- a/mantra-events/convo.go
+++ b/mantra-events/convo.go
@@ -137,6 +137,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if isValidChainName(msg.Value) {

--- a/mantra-minimal/convo.go
+++ b/mantra-minimal/convo.go
@@ -92,6 +92,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/mantra-minimal/convo.go
+++ b/mantra-minimal/convo.go
@@ -57,6 +57,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -94,6 +95,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/mantra-minimal/convo.go
+++ b/mantra-minimal/convo.go
@@ -82,7 +82,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/msgwrap.go
+++ b/msgwrap.go
@@ -234,11 +234,12 @@ func (w *MsgWrap) Description(description string) *MsgWrap {
 	return w
 }
 
-func (w *MsgWrap) ListSelect(instructions string) *MsgWrap {
+func (w *MsgWrap) ListSelect(instructions string, ID string) *MsgWrap {
 	// TODO: to a type assertion on the `lastType`, to make sure it matches what we're asking here..
 	w.Msg.Entry = &pbconvo.SystemOutput_ListSelect_{
 		ListSelect: &pbconvo.SystemOutput_ListSelect{
 			Instructions: instructions,
+			Id:           ID,
 		},
 	}
 	return w

--- a/sol-anchor/convo.go
+++ b/sol-anchor/convo.go
@@ -107,6 +107,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Values(values...).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		return c.NextStep()

--- a/sol-anchor/convo.go
+++ b/sol-anchor/convo.go
@@ -73,6 +73,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -109,6 +110,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/sol-anchor/convo.go
+++ b/sol-anchor/convo.go
@@ -102,7 +102,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	case codegen.AskChainName:
 		labels := []string{"Solana Mainnet", "Solana Devnet"}
 		values := []string{"solana-mainnet", "solana-devnet"}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
@@ -133,7 +133,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case AskIDLFormat:
 		return c.Action(InputIDLFormat{}).
-			ListSelect("How do you want to provide the JSON IDL?").
+			ListSelect("How do you want to provide the JSON IDL?", "idl_format").
 			Labels("JSON string", "JSON in a local file").
 			Values("string", "file").
 			DefaultValue("string").

--- a/sol-minimal/convo.go
+++ b/sol-minimal/convo.go
@@ -41,6 +41,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -55,6 +56,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.AskProjectName:
 		return c.CmdAskProjectName()

--- a/sol-minimal/convo.go
+++ b/sol-minimal/convo.go
@@ -53,6 +53,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 		}
 		return loop.Seq(msgCmd, c.NextStep())
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.AskProjectName:
 		return c.CmdAskProjectName()
 

--- a/sol-transactions/convo.go
+++ b/sol-transactions/convo.go
@@ -53,6 +53,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -70,6 +71,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputProjectName:
 		c.State.Name = msg.Value

--- a/sol-transactions/convo.go
+++ b/sol-transactions/convo.go
@@ -68,6 +68,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	case codegen.AskProjectName:
 		return c.CmdAskProjectName()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputProjectName:
 		c.State.Name = msg.Value
 		return c.NextStep()

--- a/starknet-events/convo.go
+++ b/starknet-events/convo.go
@@ -399,6 +399,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/starknet-events/convo.go
+++ b/starknet-events/convo.go
@@ -389,7 +389,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/starknet-events/convo.go
+++ b/starknet-events/convo.go
@@ -110,6 +110,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -401,6 +402,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/starknet-minimal/convo.go
+++ b/starknet-minimal/convo.go
@@ -73,7 +73,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/starknet-minimal/convo.go
+++ b/starknet-minimal/convo.go
@@ -83,6 +83,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/starknet-minimal/convo.go
+++ b/starknet-minimal/convo.go
@@ -48,6 +48,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -85,6 +86,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/stellar-minimal/convo.go
+++ b/stellar-minimal/convo.go
@@ -73,7 +73,7 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()

--- a/stellar-minimal/convo.go
+++ b/stellar-minimal/convo.go
@@ -83,6 +83,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/stellar-minimal/convo.go
+++ b/stellar-minimal/convo.go
@@ -48,6 +48,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -85,6 +86,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/stellar-transactions-operations/convo.go
+++ b/stellar-transactions-operations/convo.go
@@ -82,12 +82,12 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			labels = append(labels, conf.DisplayName)
 			values = append(values, conf.ID)
 		}
-		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain").
+		return c.Action(codegen.InputChainName{}).ListSelect("Please select the chain", "chain").
 			Labels(labels...).
 			Values(values...).
 			Cmd()
 	case AskFilterType:
-		return c.Action(InputFilterType{}).ListSelect("What kind of data do you want to index?\n\n- Raw transactions: you can filter the transactions based on source account at the transactions and/or operation level.\n- Operations: you can get operatios filtered by operation name\n\n").
+		return c.Action(InputFilterType{}).ListSelect("What kind of data do you want to index?\n\n- Raw transactions: you can filter the transactions based on source account at the transactions and/or operation level.\n- Operations: you can get operatios filtered by operation name\n\n", "data_type").
 			Labels("Raw transactions (filtered by source account(s))", "Operations (filtered by operation name)").
 			Values("transactions", "operations").
 			Cmd()

--- a/stellar-transactions-operations/convo.go
+++ b/stellar-transactions-operations/convo.go
@@ -57,6 +57,7 @@ func (c *Convo) NextStep() loop.Cmd {
 func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 	switch msg := msg.(type) {
 	case codegen.MsgStart:
+		c.SetClientVersion(msg.Version)
 		var msgCmd loop.Cmd
 		if msg.Hydrate != nil {
 			if err := json.Unmarshal([]byte(msg.Hydrate.SavedState), &c.State); err != nil {
@@ -127,6 +128,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 
 	case codegen.InputSubstreamsConsumptionChoice:
 		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
+	case codegen.InputSourceDownloaded:
+		return c.HandleDownloaded(msg.Value)
 
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value

--- a/stellar-transactions-operations/convo.go
+++ b/stellar-transactions-operations/convo.go
@@ -125,6 +125,9 @@ func (c *Convo) Update(msg loop.Msg) loop.Cmd {
 			Messagef(`Hmm, %q seems like an invalid chain name. Maybe it was supported and is not anymore?`, c.State.ChainName).
 			Cmd()
 
+	case codegen.InputSubstreamsConsumptionChoice:
+		return c.HandleSubstreamsConsumptionChoice(msg.Value)
+
 	case codegen.InputChainName:
 		c.State.ChainName = msg.Value
 		if c.State.IsValidChainName(msg.Value) {

--- a/types.go
+++ b/types.go
@@ -21,6 +21,9 @@ type InputConfirmCompile struct{ pbconvo.UserInput_Confirmation } // SQL specifi
 type AskInitialStartBlockType struct{}
 type InputAskInitialStartBlockType struct{ pbconvo.UserInput_TextInput }
 
+type AskSubstreamsConsumptionChoice struct{}
+type InputSubstreamsConsumptionChoice struct{ pbconvo.UserInput_Selection }
+
 func InputAskInitialStartBlockTypeTextInput() string {
 	return "At what block do you want to start indexing data?"
 }

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ type AskChainName struct{}
 type MsgInvalidChainName struct{}
 type InputChainName struct{ pbconvo.UserInput_Selection }
 
-type InputSourceDownloaded struct{ pbconvo.UserInput_Confirmation }
+type InputSourceDownloaded struct{ pbconvo.UserInput_TextInput }
 type PackageDownloaded struct{ pbconvo.UserInput_Confirmation }
 
 type AskConfirmCompile struct{}


### PR DESCRIPTION
Add simple documentation on how the user wants to consume data.


Works with SQL, Parquet, reference for other languages to write sinks with examples

With some rework on the JSON and CSV we could make it work too.
The SQL from-proto sink also will need to rename its blocknumber and blockhash and block_timestamp fields as to not collide with the ones we generate in some minimal codegens.

This should be good to go